### PR TITLE
Fixed double hearts for placeholder MagicHeart

### DIFF
--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Placeholder/Replacer/MagicHeart.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Placeholder/Replacer/MagicHeart.java
@@ -36,6 +36,6 @@ public class MagicHeart extends PlaceholderReplacerBaseValue
 	protected @Nullable String replaceMarried(MarriagePlayer player)
 	{
 		//noinspection ConstantConditions
-		return ((MarriageData) player.getMarriageData()).getMagicHeart() + valueMarried;
+		return player.getMarriageData().getColor() + valueMarried;
 	}
 }


### PR DESCRIPTION
As it was before:
`getMagicHeart()` already returns color+heart+reset
And `valueMarried` also returns the heart (according to default `config.yml->Placeholders.MagicHeart.Married: "<heart>&f"`)
Therefore command `papi parse player %marriagemaster_MagicHeart%` returns two hearts. The first one with color and the seceond with "reset" (white) color.

There were two ways to fix bug:
1, change to `return player.getMarriageData().getMagicHeart()`
2. change to `return player.getMarriageData().getColor() + valueMarried;`

But the first way makes the parameter `config.yml->Placeholders.MagicHeart.Married` useless.
Therefore, I chose the second way to fix bug.  This makes it possible to continue using the parameter from config.

PS: Also removed redundant cast `(MarriageData)`