### PR TITLE
Fixed bug with marriages duplicates in multi-partners mode + command /marry chat settarget

### DIFF
--- a/MarriageMaster/resources/lang/en.yml
+++ b/MarriageMaster/resources/lang/en.yml
@@ -163,6 +163,7 @@ Language:
     Marry:
       # Placeholders: {Name}, {DisplayName}.    Keep in mind display names contain colors!
       NotWithHimself: "&cYou can't marry &r&c{DisplayName}&r&c with himself."
+      AlreadySamePair: "&cYou can't marry players that are already married to each other. &r&c{Player1DisplayName}&r&c is already married with &r&c{Player2DisplayName}&r&c."
       AlreadyMarried: "&cYou can't marry players that are already married. &r&c{DisplayName}&r&c is already married."
       SurnameNeeded: "&cYou need a surname for the couple to marry."
       Married: "&aYou have married &r&a{Player1DisplayName}&r&a with &r&a{Player2DisplayName}&r&a."
@@ -178,6 +179,7 @@ Language:
       Self:
         NotYourself: "&cYou can't marry yourself."
         NotInRange: "&cThe player is not in range! He needs to be within {Range} blocks!"
+        AlreadySamePair: "&cWe are already married with &r&c{DisplayName}&r&c!"
         AlreadyMarried: "&cYou are already married with &r&c{DisplayName}&r&c!"
         OtherAlreadyMarried: "&c&r&c{DisplayName}&r&c is already married!"
         AlreadyOpenRequest: "&cYou have already one not answered marry request."

--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/ChatCommand.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/ChatCommand.java
@@ -49,9 +49,9 @@ public class ChatCommand extends MarryCommand implements Listener
 {
 	private final MarriageMaster plugin;
 	private final Message messageJoined, messageLeft, messageListeningStarted, messageListeningStopped, messageTargetSet;
-	private final String displayNameAll, helpParameterMessage, privateMessageFormat;
+	private final String displayNameAll, helpParameterMessage, privateMessageFormat, setTargetDescription;
 	private final Set<Player> listeners = ConcurrentHashMap.newKeySet();
-	private final String[] setTargetParameters, switchesToggle;
+	private final String[] setTargetParameters, switchesToggle, switchesAll;
 	private final boolean allowChatSurveillance;
 	private MarryCommand chatToggleCommand, chatListenCommand;
 
@@ -68,9 +68,11 @@ public class ChatCommand extends MarryCommand implements Listener
 		privateMessageFormat    = plugin.getLanguage().getMessage("Ingame.Chat.Format").getFallback().replaceAll("\\{SenderDisplayName}", "%1\\$s").replaceAll("\\{ReceiverDisplayName}", "%2\\$s").replaceAll("\\{Message}", "%3\\$s").replaceAll("\\{SenderName}", "%4\\$s").replaceAll("\\{ReceiverName}", "%5\\$s").replaceAll("\\{MagicHeart}", "%6\\$s");
 		displayNameAll          = plugin.getLanguage().getTranslated("Ingame.Chat.DisplayNameAll");
 		helpParameterMessage    = "<" + plugin.getLanguage().getTranslated("Commands.MessageVariable") + ">";
+		setTargetDescription = plugin.getLanguage().getTranslated("Commands.Description.ChatSetTarget");
 		//noinspection SpellCheckingInspection
 		setTargetParameters     = plugin.getLanguage().getCommandAliases("ChatSetTarget", new String[] { "target", "settarget" });
 		switchesToggle  = plugin.getLanguage().getSwitch("Toggle", "toggle");
+		switchesAll  = plugin.getLanguage().getSwitch("All", "all");
 		allowChatSurveillance = plugin.getConfiguration().isChatSurveillanceEnabled();
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
@@ -138,6 +140,11 @@ public class ChatCommand extends MarryCommand implements Listener
 						player.setPrivateChatTarget(getMarriagePlugin().getPlayerData(target));
 						messageTargetSet.send(sender);
 					}
+					else if(getMarriagePlugin().getCommandManager().isAllSwitch(args[1]))
+					{
+						player.setPrivateChatTarget((Marriage) null);
+						messageTargetSet.send(sender);
+					}
 					else
 					{
 						plugin.messageTargetPartnerNotFound.send(sender);
@@ -177,7 +184,12 @@ public class ChatCommand extends MarryCommand implements Listener
 			if(args.length == 2 && StringUtils.arrayContainsIgnoreCase(setTargetParameters, args[0]))
 			{
 				MarriagePlayer player = getMarriagePlugin().getPlayerData((Player) sender);
-				data = player.getMatchingPartnerNames(args[1]);
+				data.addAll(player.getMatchingPartnerNames(args[1]));
+				String arg = args[1].toLowerCase(Locale.ENGLISH);
+				for(String s : switchesAll)
+				{
+					if(s.toLowerCase(Locale.ENGLISH).startsWith(arg)) data.add(s);
+				}
 			}
 			else
 			{
@@ -185,6 +197,10 @@ public class ChatCommand extends MarryCommand implements Listener
 				{
 					String arg = args[0].toLowerCase(Locale.ENGLISH);
 					for(String s : switchesToggle)
+					{
+						if(s.toLowerCase(Locale.ENGLISH).startsWith(arg)) data.add(s);
+					}
+					for(String s : setTargetParameters)
 					{
 						if(s.toLowerCase(Locale.ENGLISH).startsWith(arg)) data.add(s);
 					}
@@ -211,7 +227,7 @@ public class ChatCommand extends MarryCommand implements Listener
 		if(getMarriagePlugin().areMultiplePartnersAllowed())
 		{
 			help.add(new HelpData(getTranslatedName() + " " + setTargetParameters[0], "<" + plugin.helpPartnerNameVariable + " / " +
-							getMarriagePlugin().getCommandManager().getAllSwitchTranslation() + ">", getDescription()));
+							getMarriagePlugin().getCommandManager().getAllSwitchTranslation() + ">", setTargetDescription));
 		}
 		return help;
 	}

--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Management/MarriageManager.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Management/MarriageManager.java
@@ -54,6 +54,7 @@ public class MarriageManager implements at.pcgamingfreaks.MarriageMaster.Bukkit.
 	private final Message messageSurnameSuccess, messageSurnameFailed, messageSurnameToShort, messageSurnameToLong, messageSurnameAlreadyUsed;
 	private final Message messageAlreadyMarried, messageNotWithHimself, messageSurnameNeeded, messageMarried, messageHasMarried, messageBroadcastMarriage, messageNotInRange, messageAlreadyOpenRequest;
 	private final Message messageNotYourself, messageSelfNotInRange, messageSelfAlreadyMarried, messageSelfOtherAlreadyMarried, messageSelfAlreadyOpenRequest, messageSelfConfirm, messageSelfMarryRequestSent;
+	private final Message messageAlreadySamePair, messageSelfAlreadySamePair;
 	private final Message messageBroadcastDivorce, messageDivorced, messageDivorcedPlayer, messageDivorceNotInRange, messageSelfNotOnYourOwn;
 	private final Message messageSelfDivorced, messageSelfBroadcastDivorce, messageSelfDivorcedPlayer, messageSelfDivorceRequestSent, messageSelfDivorceConfirm, messageSelfDivorceNotInRange;
 	private final boolean surnameAllowColors, announceMarriage, confirm, bothOnDivorce, autoDialog, otherPlayerOnSelfDivorce;
@@ -95,6 +96,7 @@ public class MarriageManager implements at.pcgamingfreaks.MarriageMaster.Bukkit.
 		messageSurnameToLong           = getMSG("Ingame.Surname.ToLong").replaceAll("\\{MinLength}", surnameMinLength + "").replaceAll("\\{MaxLength}", surnameMaxLength + "");
 		messageSurnameAlreadyUsed      = getMSG("Ingame.Surname.AlreadyUsed");
 
+		messageAlreadySamePair         = getMSG("Ingame.Marry.AlreadySamePair").replaceAll("\\{Player1Name}", "%1\\$s").replaceAll("\\{Player1DisplayName}", "%2\\$s").replaceAll("\\{Player2Name}", "%3\\$s").replaceAll("\\{Player2DisplayName}", "%4\\$s");
 		messageAlreadyMarried          = getMSG("Ingame.Marry.AlreadyMarried").replaceAll("\\{Name}", "%1\\$s").replaceAll("\\{DisplayName}", "%2\\$s");
 		messageNotWithHimself          = getMSG("Ingame.Marry.NotWithHimself").replaceAll("\\{Name}", "%1\\$s").replaceAll("\\{DisplayName}", "%2\\$s");
 		messageSurnameNeeded           = getMSG("Ingame.Marry.SurnameNeeded");
@@ -107,6 +109,7 @@ public class MarriageManager implements at.pcgamingfreaks.MarriageMaster.Bukkit.
 		messageSelfConfirm             = getMSG("Ingame.Marry.Self.Confirm").replaceAll("\\{Name}", "%1\\$s").replaceAll("\\{DisplayName}", "%2\\$s");
 		messageNotYourself             = getMSG("Ingame.Marry.Self.NotYourself");
 		messageSelfNotInRange          = getMSG("Ingame.Marry.Self.NotInRange").replaceAll("\\{Range}", "%.1f");
+		messageSelfAlreadySamePair     = getMSG("Ingame.Marry.Self.AlreadySamePair").replaceAll("\\{(Partner)?Name}", "%1\\$s").replaceAll("\\{(Partner)?DisplayName}", "%2\\$s");
 		messageSelfAlreadyMarried      = getMSG("Ingame.Marry.Self.AlreadyMarried").replaceAll("\\{Name}", "%1\\$s").replaceAll("\\{DisplayName}", "%2\\$s");
 		messageSelfMarryRequestSent    = getMSG("Ingame.Marry.Self.RequestSent");
 		messageSelfOtherAlreadyMarried = getMSG("Ingame.Marry.Self.OtherAlreadyMarried").replaceAll("\\{Name}", "%1\\$s").replaceAll("\\{DisplayName}", "%2\\$s");
@@ -364,6 +367,10 @@ public class MarriageManager implements at.pcgamingfreaks.MarriageMaster.Bukkit.
 		{
 			messageNotWithHimself.send(priest, player1.getName(), player1.getDisplayName());
 		}
+		else if (player1.getPartners().contains(player2))
+		{
+			messageAlreadySamePair.send(priest, player1.getName(), player1.getDisplayName(), player2.getName(), player2.getDisplayName());
+		}
 		else if(!plugin.areMultiplePartnersAllowed() && (player1.isMarried() || player2.isMarried()))
 		{
 			if(player1.isMarried()) messageAlreadyMarried.send(priest, player1.getName(), player1.getDisplayName());
@@ -447,13 +454,17 @@ public class MarriageManager implements at.pcgamingfreaks.MarriageMaster.Bukkit.
 					{
 						priest.send(messageSelfNotInRange, rangeMarry);
 					}
+					else if (priest.getPartners().contains(otherPlayer))
+					{
+						priest.send(messageSelfAlreadySamePair, otherPlayer.getName(), otherPlayer.getDisplayName());
+					}
 					else if(!plugin.areMultiplePartnersAllowed() && (player1.isMarried() || player2.isMarried()))
 					{
 						if(priest.isMarried())
 						{
 							priest.send(messageSelfAlreadyMarried, priest.getPartner().getName(), priest.getPartner().getDisplayName());
 						}
-						if(otherPlayer.isMarried())
+						else if(otherPlayer.isMarried())
 						{
 							priest.send(messageSelfOtherAlreadyMarried, otherPlayer.getName(), otherPlayer.getDisplayName());
 						}


### PR DESCRIPTION
The check that such a pair already exists was skipped.
As a result, duplicate pairs of married players were added to the database.
But there was only one chance to divorce.
Only one entry was deleted from the database and a second divorce required the plugin configuration reload (/marry reload)
After the appearance of duplicates, the current information on the married pair was incorrectly recognized.
For example, after setting the heart color, the old heart continued to be displayed in the list of pairs (apparently from another entry in the database)

The bug was fixed by adding a check that the players are already married TO EACH OTHER.

Also added parameters to the language configuration (so far only in en.yml):

1. Ingame.Marry.AlreadySamePair
placeholders: {Player1Name},{Player1DisplayName},{Player2Name},{Player2DisplayName}
value: `"&cYou can't marry players that are already married to each other. &r&c{Player1DisplayName}&r&c is already married with &r&c{Player2DisplayName}&r&c."`

2. Ingame.Marry.Self.AlreadySamePair
placeholders: {Name} (alias {PartnerName}), {DisplayName} (alias {PartnerDisplayName})
value: `"&cWe are already married with &r&c{DisplayName}&r&c!"`
The word "We" emphasizes that the player is already married to this partner.

PS. Also fixed duplicate message that partner is also married (single partner mode). line 476

----
Updated: I am sorry. The second PR was automatically attached here  I do not understand why, 😕 
Looks like I should do commits for every new PR in separate branches. 🤔 

### Fixed bugs with command /marry chat settarget all
Added the ability to reset the recipient of private messages (/marry chat settarget all)
Added tab complete for "settarget"/"target"
Added tab complete for "all" switch in "settarget" subcommand
Fixed description for settarget subcommand
