### PR TITLE
Add marry method for conditional execution

### DIFF
--- a/API/MarriageMaster-API-Common/src/at/pcgamingfreaks/MarriageMaster/API/MarriageManager.java
+++ b/API/MarriageMaster-API-Common/src/at/pcgamingfreaks/MarriageMaster/API/MarriageManager.java
@@ -194,4 +194,15 @@ public interface MarriageManager<MARRIAGE extends Marriage, MARRIAGE_PLAYER exte
 	 * @param surname The surname for the new married couple.
 	 */
 	void marry(@NotNull MARRIAGE_PLAYER player1, @NotNull MARRIAGE_PLAYER player2, @NotNull MARRIAGE_PLAYER priest, @Nullable String surname);
+
+	/**
+	 * Initiates a marriage between two players, instantly uniting them in-game if 'forceMarry' is set to true, bypassing any preconditions.
+	 * If 'forceMarry' is false, the marriage proceeds only if all necessary conditions are met.
+	 *
+	 * @param player1 The first player to be married, must be non-null and represents one of the entities entering into marriage.
+	 * @param player2 The second player to be married, also must be non-null, representing the other entity entering into marriage.
+	 * @param forceMarry A boolean indicating the marriage type. True for immediate marriage without precondition checks,
+	 *                   false for a conditional marriage that requires all preconditions to be satisfied.
+	 */
+	void marry(@NotNull MARRIAGE_PLAYER player1, @NotNull MARRIAGE_PLAYER player2, boolean forceMarry);
 }

--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Management/MarriageManagerImpl.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Management/MarriageManagerImpl.java
@@ -169,7 +169,7 @@ public final class MarriageManagerImpl implements at.pcgamingfreaks.MarriageMast
 		SelfDivorceAcceptRequest.unLoadMessages();
 		PriestDivorceAcceptRequest.unLoadMessages();
 	}
-	
+
 	private Message getMSG(String path)
 	{
 		return plugin.getLanguage().getMessage(path);
@@ -410,6 +410,22 @@ public final class MarriageManagerImpl implements at.pcgamingfreaks.MarriageMast
 			return true;
 		}
 		return false;
+	}
+
+	@Override
+	public void marry(@NotNull MarriagePlayer player1, @NotNull MarriagePlayer player2, boolean forceMarry)
+	{
+		if (forceMarry)
+		{
+			MarriageData marriage = new MarriageData(player1, player2, null, null);
+			plugin.getDatabase().cachedMarry(marriage);
+			messageBroadcastMarriage.broadcast(CONSOLE_NAME, CONSOLE_DISPLAY_NAME_COMPONENT, player1, player2);
+			plugin.getServer().getPluginManager().callEvent(new MarriedEvent(marriage));
+		}
+		else
+		{
+			marry(player1, player2);
+		}
 	}
 
 	public void marryPriestFinish(MarriagePlayer player1, MarriagePlayer player2, CommandSender priest, String surname)


### PR DESCRIPTION
Add a marry method to support immediate marriage with 'forceMarry' flag, bypassing precondition checks when true. Ensured compatibility with conditional marriages requiring all preconditions to be met when 'forceMarry' is false.


