### PR TITLE
Use Paper's teleportAsync if available

### DIFF
--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/HomeCommand.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/HomeCommand.java
@@ -257,7 +257,7 @@ public class HomeCommand extends MarryCommand
 						player.send(messageNoHome);
 						return;
 					}
-					player.getPlayerOnline().teleport(marriage.getHome().getLocation());
+					TpCommand.teleportAsync(player.getPlayerOnline(), marriage.getHome().getLocation());
 					player.send(messageTPed);
 				}
 				else

--- a/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/TpCommand.java
+++ b/MarriageMaster/src/at/pcgamingfreaks/MarriageMaster/Bukkit/Commands/TpCommand.java
@@ -42,10 +42,13 @@ import org.jetbrains.annotations.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class TpCommand extends MarryCommand
 {
@@ -197,7 +200,7 @@ public class TpCommand extends MarryCommand
 				}
 				else
 				{
-					player.teleport(loc);
+					teleportAsync(player, loc);
 					messageTeleport.send(player);
 					messageTeleportTo.send(partner);
 				}
@@ -210,6 +213,16 @@ public class TpCommand extends MarryCommand
 		else
 		{
 			messagePartnerVanished.send(player);
+		}
+	}
+
+	public static CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
+		try {
+			Method method = player.getClass().getMethod("teleportAsync", Location.class);
+			return (CompletableFuture<Boolean>) method.invoke(player, location);
+		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+			// paper's teleportAsync not found, fallback to bukkit's teleport
+			return CompletableFuture.completedFuture(player.teleport(location));
 		}
 	}
 


### PR DESCRIPTION
Player.teleportAsync should be used wherever possible to reduce synchronous chunk loads and support multithreaded server implementations.

This PR attempts to use `teleportAsync` if it's available like on Paper servers, but will otherwise fall back to `teleport` on servers such as Spigot.